### PR TITLE
Do not put '\n' into error message

### DIFF
--- a/lib/client/methods/promises.js
+++ b/lib/client/methods/promises.js
@@ -61,7 +61,7 @@ module.exports = function(Promise) {
       var owner = this._owner
       this._owner = null
       clearTimeout(this._callTimer)
-      var err = new Error(util.format('%s\n in service %s method %s\n args: %s\n', message, owner._name, this._methodId, util.inspect(this._args)))
+      var err = new Error(util.format('%s in service %s method %s args: %s', message, owner._name, this._methodId, util.inspect(this._args)))
       err.code = code
       Promise.reject(this.deferred, err)
     }


### PR DESCRIPTION
Output will be truncated:

`Error: undefined` instead of `Error: undefined in service geobase method 11 args: [ 143 ]`
