### PR TITLE
Print error, if logMethod failed

### DIFF
--- a/lib/client/logger.js
+++ b/lib/client/logger.js
@@ -22,7 +22,14 @@ function logMethod(level){
       } else {
         var args = arguments
         var message = format.apply(null, args)
-        this._logging.emit(level, this._target, message)
+        this._logging.emit(level, this._target, message, function (err) {
+          if (err) {
+            console.error('There was an error, while sending logs:');
+            console.error(err);
+            console.error('Following message is not delivered:');
+            console.error(level, this._target, message);
+          }
+        })
       }
       if(VL.debug <= level){
         console.log(message)


### PR DESCRIPTION
If callback is not specified, then logMethod is failing silently. It is better to log something out (at least in console), so crashlog can pickup it later for investigation.
